### PR TITLE
Added a check to prevent FAQ tag duplication

### DIFF
--- a/utilities/tbfaq_utilities.py
+++ b/utilities/tbfaq_utilities.py
@@ -11,6 +11,8 @@ from css_html_js_minify import js_minify, css_minify
 TAB_SPACE = "    "
 TAB_LENGTH = len(TAB_SPACE)
 
+faqitems = dict() ## A dictionary of faq item tags to cleaned faq item HTML files.
+
 def isnotWS(s):
     l = len(s)
     i = 0
@@ -205,6 +207,18 @@ def clean_html():
             with open(tgtpath + "/" + newtitle, "wb") as of:
                 of.write(cleaned[1].encode("utf-8"))
                 print(' --> "' + tgtpath + "/" + newtitle + '" saved.')
+
+            if fname[0] in faqitems:
+                faqitems[fname[0]].add(tgtpath+"/"+newtitle)
+            else:
+                faqitems[fname[0]] = {tgtpath+"/"+newtitle}
+
+    for k,v in faqitems.items():
+        if len(v) > 1:
+            print(" -!- clean_html: FAQ tag `" + k + "` is used multiple times:")
+            for f in v:
+                print("               : --> " + f)
+            print("               : This cannot be implemented on live!")
 
 def clean_js():
     if not os.path.exists(gitdir + "/../js"):

--- a/utilities/tbfaq_utilities.py
+++ b/utilities/tbfaq_utilities.py
@@ -22,6 +22,8 @@ def isnotWS(s):
         i+=1
     return False
 
+singleton_tags = {"hr","img","input"} # tags which can exist on their own without internal data.
+
 class faqparser(HTMLParser):
     cf = ""
     titlenext = False
@@ -84,7 +86,7 @@ class faqparser(HTMLParser):
             if tag == 'br':
                 return
             newdat = '</' + tag + '>'
-            if tag == self.lasttag and tag != 'img' and tag != 'hr':
+            if tag == self.lasttag and not (tag in singleton_tags):
                 if tag == 'span':
                     if ('class', 'drop_arrow_bbc') in self.lastattr:
                         if not self.datasince:


### PR DESCRIPTION
Since the ACP page for `faq.php` indexes individual items by their complete ID, we can't reuse these IDs in multiple categories. This commit adds the ability to detect that to the utilities package.