### PR TITLE
Update boosters_and_subscriptions.html

### DIFF
--- a/FAQ Items/Account/boosters_and_subscriptions.html
+++ b/FAQ Items/Account/boosters_and_subscriptions.html
@@ -71,6 +71,7 @@
 								<strong class="drop_title_bbc">QI Booster <span class="drop_arrow_bbc">►</span></strong>
 								<ul class="drop_content_bbc">
 									<li>Buying this subscription will make you earn twice as many Qi points for each fight during a month.</li>
+									<li>Please note this does <b>not</b> raise the daily Qi limit of 100 games. You will merely reach this limit twice as fast.</li>
 								</ul>
 							</div>
 						</li>
@@ -78,7 +79,7 @@
 							<div class="dropdown_bbc">
 								<strong class="drop_title_bbc">TC Boosters <span class="drop_arrow_bbc">►</span></strong>
 								<ul class="drop_content_bbc">
-									<li>Buying a TC booster will increase the amount of TC you earn per win for a month. The amount won depends on the specific booster you bought. <strong style="color: red;">TC boosters will only increase your earnings in any room until you reach the daily 100 QI limit.</strong></li>
+									<li>Buying a TC booster will increase the amount of TC you earn per win for a month. The amount won depends on the specific booster you bought. <strong style="color: red;">TC boosters will only increase your earnings in any room until you reach the daily 100 boost (wins) limit. You can continue playing past the 100 Qi limit, but it won't count towards your Qi any more.</strong></li>
 								</ul>
 							</div>
 						</li>

--- a/FAQ Items/Account/boosters_and_subscriptions.html
+++ b/FAQ Items/Account/boosters_and_subscriptions.html
@@ -36,31 +36,35 @@
 						<li>
 							<div class="dropdown_bbc">
 								<strong class="drop_title_bbc">Forum VIP <span class="drop_arrow_bbc">►</span></strong>
-								<ul class="drop_content_bbc">
-									<li>This subscription adds a ton of features to your forum experience, including:</li>
-									<li>Bigger 150x150 px and animated avatars</li>
-									<li>Have more room (up to 6 lines) and use images in your signature</li>
-									<li>Forum name prefix of your choice</li>
-									<li>Post background images</li>
-									<li>Global forum search functionality</li>
-									<li>Forum VIP exclusive board access</li>
-								</ul>
+								<div class="drop_content_bbc">
+									<p>
+									<ul>
+										<li>This subscription adds a ton of features to your forum experience, including:</li>
+										<li>Bigger 150x150 px and animated avatars</li>
+										<li>Have more room (up to 6 lines) and use images in your signature</li>
+										<li>Forum name prefix of your choice</li>
+										<li>Post background images</li>
+										<li>Global forum search functionality</li>
+										<li>Forum VIP exclusive board access</li>
+									</ul>
+									</p>
+								</div>
 							</div>
 						</li>
 						<li>
 							<div class="dropdown_bbc">
 								<strong class="drop_title_bbc">Wibbles Access <span class="drop_arrow_bbc">►</span></strong>
-								<ul class="drop_content_bbc">
-									<li>This subscription will give you access to the (otherwise hidden) wibbles board for 30 days. Wibbles is a completely off-topic board with very little moderation. <strong>This subscription is non-repeating and must be re-purchased at the end of its lifespan.</strong></li>
-								</ul>
+								<div class="drop_content_bbc">
+									<p>This subscription will give you access to the (otherwise hidden) wibbles board for 30 days. Wibbles is a completely off-topic board with very little moderation. <strong>This subscription is non-repeating and must be re-purchased at the end of its lifespan.</strong></p>
+								</div>
 							</div>
 						</li>
 						<li>
 							<div class="dropdown_bbc">
 								<strong class="drop_title_bbc">Wibbles Anonymity <span class="drop_arrow_bbc">►</span></strong>
-								<ul class="drop_content_bbc">
-									<li>Buying this causes all your posts in the Wibbles board to become anonymous - all your identifying details will be hidden. <strong style="color: red;">THIS WILL NOT GIVE YOU ACCESS TO WIBBLES BY ITSELF - SEE THE 'WIBBLES ACCESS' SUBSCRIPTION FOR THAT.</strong> <strong>This subscription is non-repeating and must be re-purchased at the end of its lifespan.</strong></li>
-								</ul>
+								<div class="drop_content_bbc">
+									<p>Buying this causes all your posts in the Wibbles board to become anonymous - all your identifying details will be hidden. <strong style="color: red;">THIS WILL NOT GIVE YOU ACCESS TO WIBBLES BY ITSELF - SEE THE 'WIBBLES ACCESS' SUBSCRIPTION FOR THAT.</strong> <strong>This subscription is non-repeating and must be re-purchased at the end of its lifespan.</strong></p>
+								</div>
 							</div>
 						</li>
 					</ul>
@@ -68,30 +72,28 @@
 					<ul>
 						<li>
 							<div class="dropdown_bbc">
-								<strong class="drop_title_bbc">QI Booster <span class="drop_arrow_bbc">►</span></strong>
-								<ul class="drop_content_bbc">
-									<li>Buying this subscription will make you earn twice as many Qi points for each fight during a month.</li>
-									<li>Please note this does <b>not</b> raise the daily Qi limit of 100 games. You will merely reach this limit twice as fast.</li>
-								</ul>
+								<strong class="drop_title_bbc">Qi Booster <span class="drop_arrow_bbc">►</span></strong>
+								<div class="drop_content_bbc">
+									<p>Buying this subscription will make you earn twice as many Qi points for each fight during a month.</p>
+									<p>Please note this does <b>not</b> raise the daily Qi limit of 100 games. You will merely reach this limit twice as fast.</p>
+								</div>
 							</div>
 						</li>
 						<li>
 							<div class="dropdown_bbc">
 								<strong class="drop_title_bbc">TC Boosters <span class="drop_arrow_bbc">►</span></strong>
-								<ul class="drop_content_bbc">
-									<li>Buying a TC booster will increase the amount of TC you earn per win for a month. The amount won depends on the specific booster you bought. <strong style="color: red;">TC boosters will only increase your earnings in any room until you reach the daily 100 boost (wins) limit. You can continue playing past the 100 Qi limit, but it won't count towards your Qi any more.</strong></li>
-								</ul>
+								<div class="drop_content_bbc">
+									<p>Buying a TC booster will increase the amount of TC you earn per win for a month. The amount won depends on the specific booster you bought. <strong style="color: red;">TC boosters will only increase your earnings in any room until you reach the daily 100 boost (wins) limit. You can continue playing past the 100 Qi limit, but it won't count towards your Qi any more.</strong></p>
+								</div>
 							</div>
 						</li>
 					</ul>
-				</div><br>
-				<br>
+				</div>
 				<p class="faq_question"><span class="faq_q">Q:</span> My subscription didn't activate!</p>
 				<div class="faq_answer">
 					<p><span class="faq_a">A:</span> Email <a href="mailto:support@toribash.com">support@toribash.com</a> or <a href="http://forum.toribash.com/private.php?do=newpm&u=16251">contact hampa via PM</a>. When emailing <a href="mailto:support@toribash.com">support@toribash.com</a>, please be patient.</p>
 					<p>If you don't get a response within three days, feel free to shoot an email again.</p>
-				</div><br>
-				<br>
+				</div>
 				<p class="faq_question"><span class="faq_q">Q:</span> How can I cancel a repeating subscription?</p>
 				<div class="faq_answer">
 					<p><span class="faq_a">A:</span> Follow these steps:</p>

--- a/FAQ Items/Account/boosters_and_subscriptions.html
+++ b/FAQ Items/Account/boosters_and_subscriptions.html
@@ -92,7 +92,7 @@
 					<p>If you don't get a response within three days, feel free to shoot an email again.</p>
 				</div><br>
 				<br>
-				<p class="faq_question"><span class="faq_q">Q:</span> How can I cancel a repeat subscription?</p>
+				<p class="faq_question"><span class="faq_q">Q:</span> How can I cancel a repeating subscription?</p>
 				<div class="faq_answer">
 					<p><span class="faq_a">A:</span> Follow these steps:</p>
 					<ol style="list-style-type: decimal">


### PR DESCRIPTION
qi booster: earn the daily qi limit twice as fast, does not double qi cap (checked with sir)
tc booster: you can continue playing past the qi limit until you hit 100 wins per day, boost limit and qi limit are separate entities

feel free to alter the wording, I added small notes to the lines but I feel like they could be worded better (particularly the tc booster part)