### PR TITLE
Fixes an issue with generated min.js

### DIFF
--- a/utilities/tbfaq_utilities.py
+++ b/utilities/tbfaq_utilities.py
@@ -234,6 +234,8 @@ def clean_js():
             if fname[len(fname)-1] == "js" and fname[len(fname)-2] != "min":
                 with open(root + "/" + f, "rb") as ijs:
                     alljs += ijs.read().decode()
+                    if alljs[len(alljs)-1] != ";":
+                        alljs += ";"
                     alljs += "\n"
     minjs = js_minify(alljs)
     with open(tgtdir + "/min.js","wb") as ojs:


### PR DESCRIPTION
Prevents unterminated identifiers in one file from breaking the entire file when new statements start at the beginning of the next.